### PR TITLE
Use typescript-eslint/no-shadow

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@instacart/eslint-config",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Instacart's ESLint configuration",
   "main": "index.js",
   "scripts": {

--- a/packages/eslint-config/rules/typescript.js
+++ b/packages/eslint-config/rules/typescript.js
@@ -171,4 +171,7 @@ module.exports = {
 
   // Warns for any two overloads that could be unified into one.
   '@typescript-eslint/unified-signatures': 'off',
+
+  // Disallow variable declarations from shadowing variables declared in the outer scope.
+  '@typescript-eslint/no-shadow': 'error',
 }

--- a/packages/eslint-config/typescript.js
+++ b/packages/eslint-config/typescript.js
@@ -46,6 +46,7 @@ module.exports = {
         // disable the base rule as it can report incorrect errors
         camelcase: 'off',
         indent: 'off',
+        'no-shadow': 'off',
       }),
     },
   ],


### PR DESCRIPTION
https://github.com/instacart/javascript/pull/239 introduced false positives with eslint `no-shadow` rule. Now we need to use the `@typescript-eslint/no-shadow` rule for ts/tsx files.

https://github.com/typescript-eslint/typescript-eslint/issues/2483

<img width="1110" alt="Screen Shot 2021-02-23 at 9 42 12 AM" src="https://user-images.githubusercontent.com/133814/108860274-0a2db080-75bc-11eb-9bee-56db01d10127.png">
